### PR TITLE
Allowing installing this with SilverStripe 3.1.0rc2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require":
     {
         "silverstripe/framework": "3.1.*",
-        "silverstripe/comments": "dev-master"
+        "silverstripe/comments": "*"
     },
     "extra": {
         "installer-name": "comments-notifications"


### PR DESCRIPTION
Installing SilverStripe with the `3.1.0rc2` and trying to add this module via Composer gave me an error. This change let's me install it.
