### PR TITLE
Remove custom headers for mail server compatibility

### DIFF
--- a/code/extensions/CommentingControllerNotificationsExtension.php
+++ b/code/extensions/CommentingControllerNotificationsExtension.php
@@ -27,17 +27,14 @@ class CommentingControllerNotificationsExtension extends Extension {
 		$email->setTemplate(Config::inst()->get('CommentsNotifications', 'email_template'));
 		$email->populateTemplate($comment);
 		
-		// Corretly set sender and from as per email convention
+		// Correctly set sender and from as per email convention
 		$sender = Config::inst()->get('CommentsNotifications', 'email_sender');
 		if(!empty($comment->Email)) {
 			$email->setFrom($comment->Email);
-			$email->addCustomHeader ('Reply-To', $comment->Email);
 		} else {
 			$email->setFrom($sender);
 		}
-		$email->addCustomHeader('X-Sender', $sender);
-		$email->addCustomHeader('Sender', $sender);
-		
+
 		$this->owner->extend('updateEmail', $email);
 		
 		// Send


### PR DESCRIPTION
There's no way to remove custom headers, and some large mail server providers do not allow custom sender/reply-to headers (Amazon Web Services SES, for example).

The "From" header is fine since it can be overridden with updateEmail hook.
It may be best to add a "deleteCustomHeader" function on the Email, but this update makes the module usable in these cases in the meantime.  
